### PR TITLE
Update kong_cassandra.yaml

### DIFF
--- a/kong_cassandra.yaml
+++ b/kong_cassandra.yaml
@@ -49,6 +49,7 @@ spec:
     app: kong  
 
 ---
+apiVersion: v1
 kind: Service
 metadata:
   name: kong-admin-ssl


### PR DESCRIPTION
`apiVersion` flag missing from `kong-admin-ssl` section