### PR TITLE
Remove extra lines in computed yaml

### DIFF
--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -33,39 +33,39 @@ spec:
             value: "/dev/stderr"
           - name: KONG_LOG_LEVEL
             value: {{ .Values.kong.logLevel }}
-        {{ if .Values.kong.database.useCassandra }}
+        {{- if .Values.kong.database.useCassandra }}
           - name: KONG_DATABASE
             value: "cassandra"
-          {{ if .Values.cassandra.enabled }}
+          {{- if .Values.cassandra.enabled }}
           - name: KONG_CASSANDRA_CONTACT_POINTS
             value: {{ template "kong.cassandra.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
-          {{ else }}
+          {{- else }}
           - name: KONG_CASSANDRA_CONTACT_POINTS
             value: {{ .Values.kong.database.cassandra.contactPoints }}
-          {{ end }}
+          {{- end }}
           - name: KONG_CASSANDRA_PORT
             value: {{ .Values.kong.database.cassandra.port | quote }}
           - name: KONG_CASSANDRA_KEYSPACE
             value: {{ .Values.kong.database.cassandra.keyspace}}
           - name: KONG_CASSANDRA_REPL_FACTOR
             value: {{ .Values.kong.database.cassandra.replication | quote }}
-        {{ else }}
+        {{- else }}
           - name: KONG_PG_DATABASE
             value: {{ .Values.kong.database.postgres.database }}
           - name: KONG_PG_USER
             value: {{ .Values.kong.database.postgres.username }}
           - name: KONG_PG_PASSWORD
             value: {{ .Values.kong.database.postgres.password }}
-          {{ if .Values.postgresql.enabled }}
+          {{- if .Values.postgresql.enabled }}
           - name: KONG_PG_HOST
             value: {{ template "kong.postgresql.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
-          {{ else }}
+          {{- else }}
           - name: KONG_PG_HOST
             value: {{ .Values.kong.database.postgres.host }}
-          {{ end }}
+          {{- end }}
           - name: KONG_PG_PORT
             value: {{ .Values.kong.database.postgres.port | quote }}
-        {{ end }}
+        {{- end }}
         command: [ "/bin/sh", "-c", "kong start --run-migrations --vv" ]
         ports:
         - name: admin


### PR DESCRIPTION
Tiny cleanup for you.  Just removing the extra lines inserted by the if/else blocks.  Doesn't really impact anything or anyone, but I figured I'd send this in while I was looking at other stuff in there.