### PR TITLE
Add loadBalancerIP value to service-kong-proxy

### DIFF
--- a/charts/kong/templates/service-kong-proxy.yaml
+++ b/charts/kong/templates/service-kong-proxy.yaml
@@ -4,6 +4,11 @@ metadata:
   name: {{ template "kong.fullname" . }}-proxy
 spec:
   type: {{ .Values.kong.proxy.type }}
+  {{- if eq .Values.kong.proxy.type "LoadBalancer" }}
+  {{- if .Values.kong.proxy.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.kong.proxy.loadBalancerIP }}
+  {{- end }}
+  {{- end }}
   ports:
   - name: kong-proxy
     port: {{ .Values.kong.proxy.servicePort }}

--- a/charts/kong/templates/service-kong-proxy.yaml
+++ b/charts/kong/templates/service-kong-proxy.yaml
@@ -4,10 +4,8 @@ metadata:
   name: {{ template "kong.fullname" . }}-proxy
 spec:
   type: {{ .Values.kong.proxy.type }}
-  {{- if eq .Values.kong.proxy.type "LoadBalancer" }}
-  {{- if .Values.kong.proxy.loadBalancerIP }}
+  {{- if and (eq .Values.kong.proxy.type "LoadBalancer") .Values.kong.proxy.loadBalancerIP }}
   loadBalancerIP: {{ .Values.kong.proxy.loadBalancerIP }}
-  {{- end }}
   {{- end }}
   ports:
   - name: kong-proxy

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -17,6 +17,7 @@ kong:
     containerPort: 8000
     containerSSLPort: 8443
     type: NodePort #Options: NodePort, ClusterIP, LoadBalancer
+    loadBalancerIP: null #Set this to an IP if you want your LoadBalancer to reuse an existing IP
   logLevel: debug #Options: debug, info, notice, warn, error, crit, alert, emerg
   database:
     useCassandra: false


### PR DESCRIPTION
As I was updating from an earlier version of this chart, I wanted to reuse the existing static external IP for service-kong-proxy.  Adding the loadBalancerIP does this.

This PR should only add loadBalancerIP to the service-kong-proxy.yaml if the service type is 'LoadBalancer' and loadBalancerIP is not null.

This works for me on GCE, and it looks like some people have confirmed that this works on AWS (https://github.com/kubernetes/kubernetes/issues/10323).