### PR TITLE
Change the useCassandra parameter to something a little more obvious

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -61,7 +61,7 @@ their default values. For [`Cassandra`](./charts/cassandra/README.md) and
 ### Database-specific parameters
 
 Kong has a choice of either Postgres or Cassandra as a backend datatstore.
-This chart allows you to choose either of them with the `kong.database.useCassandra`
+This chart allows you to choose either of them with the `kong.database.type`
 parameter.  Postgres is chosen by default.
 
 Additionally, this chart allows you to use your own database or spin up a new
@@ -74,7 +74,7 @@ Postgres is enabled by default.
 | -----------------------------------    | --------------------------------------------------------------------   | -------------------   |
 | cassandra.enabled                      | Spin up a new cassandra cluster for Kong                               | `false`               |
 | postgres.enabled                       | Spin up a new postgres instance for Kong                               | `true `               |
-| kong.database.useCassandra             | Set to `true` to use Cassandra as Kong's database                      | `false`               |
+| kong.database.type                     | Choose either `postgres` or `cassandra`                                | `postgres`            |
 | kong.database.postgres.username        | Postgres username                                                      | `kong`                |
 | kong.database.postgres.database        | Postgres database name                                                 | `kong`                |
 | kong.database.postgres.password        | Postgres database password                                             | `kong`                |

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
             value: "/dev/stderr"
           - name: KONG_LOG_LEVEL
             value: {{ .Values.kong.logLevel }}
-        {{- if .Values.kong.database.useCassandra }}
+        {{- if eq .Values.kong.database.type "cassandra"}}
           - name: KONG_DATABASE
             value: "cassandra"
           {{- if .Values.cassandra.enabled }}
@@ -57,7 +57,7 @@ spec:
             value: {{ .Values.kong.database.cassandra.keyspace}}
           - name: KONG_CASSANDRA_REPL_FACTOR
             value: {{ .Values.kong.database.cassandra.replication | quote }}
-        {{- else }}
+        {{- else if eq .Values.kong.database.type "postgres"}}
           - name: KONG_PG_DATABASE
             value: {{ .Values.kong.database.postgres.database }}
           - name: KONG_PG_USER

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -23,7 +23,7 @@ kong:
     useTLS: true
   logLevel: debug #Options: debug, info, notice, warn, error, crit, alert, emerg
   database:
-    useCassandra: false
+    type: postgres #Options: postgres, cassandra
     postgres:
       username: kong
       database: kong


### PR DESCRIPTION
I thought the useCassandra parameter would have limited shelf-life if more backends were made available.  I also found it a little confusing the first time I went through the chart, so I thought I'd suggest something a little more explicit.