### PR TITLE
Fix local minikube'ability

### DIFF
--- a/cassandra.yaml
+++ b/cassandra.yaml
@@ -90,9 +90,7 @@ spec:
   # do not use these in production until ssd GCEPersistentDisk or other ssd pd
   volumeClaimTemplates:
   - metadata:
-      name: cassandra-data
-      annotations:
-        volume.beta.kubernetes.io/storage-class: fast
+      name: cassandra-data-pvc-0
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
@@ -100,9 +98,36 @@ spec:
           storage: 1Gi
 ---
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
-  name: fast
-provisioner: kubernetes.io/gce-pd
-parameters:
-  type: pd-ssd
+  name: local-storage
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: pv0001
+  labels:
+    type: local
+spec:
+  storageClassName: local-storage
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/opt/pvs"
+
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: cassandra-data-pvc-0
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+


### PR DESCRIPTION
The cassandra.yaml file required significant changes to work with my
minikube installation due to errors with PersistentVolumeClaims and not
having a networked volume store.

This update defines new PV and PVC elements to work locally, replacing
the gce-pd provisioner with no-provisioner and using a local host path.