### PR TITLE
fix: set KONG_LOG_LEVEL to notice

### DIFF
--- a/kong-control-plane-cassandra.yaml
+++ b/kong-control-plane-cassandra.yaml
@@ -87,7 +87,7 @@ spec:
           - name: KONG_CASSANDRA_KEYSPACE
             value: kong
           - name: KONG_LOG_LEVEL
-            value: debug
+            value: notice
           - name: KONG_ADMIN_ACCESS_LOG
             value: /dev/stdout
           - name: KONG_PROXY_ERROR_LOG

--- a/kong-control-plane-postgres.yaml
+++ b/kong-control-plane-postgres.yaml
@@ -83,7 +83,7 @@ spec:
           - name: KONG_PG_HOST
             value: postgres.kong.svc
           - name: KONG_LOG_LEVEL
-            value: debug
+            value: notice
           - name: KONG_ADMIN_ACCESS_LOG
             value: /dev/stdout
           - name: KONG_PROXY_ERROR_LOG

--- a/kong-dbless.yaml
+++ b/kong-dbless.yaml
@@ -27,7 +27,7 @@ spec:
           - name: KONG_DATABASE
             value: 'off'
           - name: KONG_LOG_LEVEL
-            value: debug
+            value: notice
           - name: KONG_ADMIN_ACCESS_LOG
             value: /dev/stdout
           - name: KONG_PROXY_ERROR_LOG

--- a/kong-ingress-data-plane-cassandra.yaml
+++ b/kong-ingress-data-plane-cassandra.yaml
@@ -33,7 +33,7 @@ spec:
           - name: KONG_CASSANDRA_KEYSPACE
             value: kong
           - name: KONG_LOG_LEVEL
-            value: debug
+            value: notice
           - name: KONG_ADMIN_ACCESS_LOG
             value: /dev/stdout
           - name: KONG_PROXY_ERROR_LOG

--- a/kong-ingress-data-plane-postgres.yaml
+++ b/kong-ingress-data-plane-postgres.yaml
@@ -31,7 +31,7 @@ spec:
           - name: KONG_PG_HOST
             value: postgres.kong.svc
           - name: KONG_LOG_LEVEL
-            value: debug
+            value: notice
           - name: KONG_ADMIN_ACCESS_LOG
             value: /dev/stdout
           - name: KONG_PROXY_ERROR_LOG


### PR DESCRIPTION
The default log level should be notice and not debug.

If a user runs into issues, then changing it to
debug makes sense.