### PR TITLE
feat: automatic reloads for DB-less deployment

### DIFF
--- a/kong-dbless.yaml
+++ b/kong-dbless.yaml
@@ -20,6 +20,22 @@ spec:
         app: kong-dbless
     spec:
       containers:
+      - name: hupit
+        image: hbagdi/hupit:v0.1.0
+        command: [ "hupit", "--file", "/kong", "--command", "curl -v http://localhost:8001/config -F 'config=@/kong/declarative.yaml'"]
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8042
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8042
+        volumeMounts:
+          - name: kongdeclarative
+            mountPath: /kong
       - name: kong-dbless
         image: kong
         imagePullPolicy: IfNotPresent
@@ -35,15 +51,14 @@ spec:
           - name: KONG_ADMIN_ERROR_LOG
             value: /dev/stderr
           - name: KONG_ADMIN_LISTEN
-            value: 'off'
+            value: '127.0.0.1:8001'
           - name: KONG_PROXY_LISTEN
             value: 0.0.0.0:8000,0.0.0.0:8443 ssl
           - name: KONG_DECLARATIVE_CONFIG
-            value: /etc/kong/declarative.yaml
+            value: /kong/declarative.yaml
         volumeMounts:
           - name: kongdeclarative
-            mountPath: /etc/kong/declarative.yaml
-            subPath: declarative.yaml
+            mountPath: /kong
         ports:
         - name: data-http
           containerPort: 8000


### PR DESCRIPTION
This commit introduces a co-located (aka sidecar) process
to the Kong process which runs without a database.

Whenever the ConfigMap holding Kong's configuration is changed,
Kubelet will update the file. This updated file is then picked up by
hupit, and is sent to Kong via the `/config` endpiont.

This setup results in updates to ConfigMap automatically being picked up
by Kong.

There will be a slight delay involved between updating a ConfigMap and
Kong actually receiving it.
From
https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#add-configmap-data-to-a-volume:
When a ConfigMap already being consumed in a volume is updated, projected keys are eventually updated as well. Kubelet is checking whether the mounted ConfigMap is fresh on every periodic sync. However, it is using its local ttl-based cache for getting the current value of the ConfigMap. As a result, the total delay from the moment when the ConfigMap is updated to the moment when new keys are projected to the pod can be as long as kubelet sync period (1 minute by default) + ttl of ConfigMaps cache (1 minute by default) in kubelet.

Also, the subPath in the VolumeMount has been removed to avoid hiting
the bug: https://github.com/kubernetes/kubernetes/issues/50345