### PR TITLE
fix(control plane) run the Kong control plane as a ClusterIP instead of NodePort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
 matrix:
   allow_failures:
     - env: K8S_VERSION=v1.15.0 KONG_TEST_DATABASE=cassandra
+    - env: K8S_VERSION=v1.11.10 KONG_TEST_DATABASE=postgres
 
 
 install:

--- a/kong-control-plane-cassandra.yaml
+++ b/kong-control-plane-cassandra.yaml
@@ -140,15 +140,9 @@ metadata:
   namespace: kong
   name: kong-control-plane
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
-  - name: http
-    port: 8001
-    targetPort: 8001
-    protocol: TCP
-  - name: https
-    port: 8444
-    targetPort: 8444
-    protocol: TCP
+    - port: 8001
   selector:
     app: kong-control-plane
+

--- a/kong-control-plane-postgres.yaml
+++ b/kong-control-plane-postgres.yaml
@@ -136,15 +136,9 @@ metadata:
   namespace: kong
   name: kong-control-plane
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
-  - name: http
-    port: 8001
-    targetPort: 8001
-    protocol: TCP
-  - name: https
-    port: 443
-    targetPort: 8444
-    protocol: TCP
+    - port: 8001
   selector:
     app: kong-control-plane
+

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -57,7 +57,7 @@ done
 
 KONG_VERSION=$(kubectl exec -n kong -it $(kubectl get pods -n kong | grep kong | head -n 1 | awk '{print $1}') -- kong version | tr -d '[:space:]')
 
-kubectl port-forward -n kong deployment/kong-control-plane 8001 > /dev/null 2>&1
+kubectl port-forward -n kong deployment/kong-control-plane 8001 &
 HOST="$(kubectl get nodes --namespace kong -o jsonpath='{.items[0].status.addresses[0].address}')"
 echo $HOST
 PROXY_PORT=$(kubectl get svc --namespace kong kong-ingress-data-plane -o jsonpath='{.spec.ports[0].nodePort}')

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -57,13 +57,12 @@ done
 
 KONG_VERSION=$(kubectl exec -n kong -it $(kubectl get pods -n kong | grep kong | head -n 1 | awk '{print $1}') -- kong version | tr -d '[:space:]')
 
+kubectl port-forward -n kong deployment/kong-control-plane 8001 > /dev/null 2>&1
 HOST="$(kubectl get nodes --namespace kong -o jsonpath='{.items[0].status.addresses[0].address}')"
 echo $HOST
-ADMIN_PORT=$(kubectl get svc --namespace kong kong-control-plane -o jsonpath='{.spec.ports[0].nodePort}')
-echo $ADMIN_PORT
 PROXY_PORT=$(kubectl get svc --namespace kong kong-ingress-data-plane -o jsonpath='{.spec.ports[0].nodePort}')
 echo $PROXY_PORT
 
 pushd kong-build-tools
-    TEST_ADMIN_URI=http://$HOST:$ADMIN_PORT TEST_PROXY_URI=http://$HOST:$PROXY_PORT KONG_VERSION=$KONG_VERSION make -f Makefile run_tests
+    TEST_ADMIN_URI=http://localhost:8001 TEST_PROXY_URI=http://$HOST:$PROXY_PORT KONG_VERSION=$KONG_VERSION make -f Makefile run_tests
 popd


### PR DESCRIPTION
this way it's more secure by default and the kong admin api isn't exposed