### PR TITLE
chore(dependency) bump the kong-build-tools dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KONG_BUILD_TOOLS?=2.0.0
+KONG_BUILD_TOOLS?=2.0.3
 KONG_TEST_DATABASE?=postgres
 
 setup-kong-build-tools:


### PR DESCRIPTION
bump kong-build-tools. Most notable change is we don't use buildx if AWS credentials aren't present.