### PR TITLE
feat(bootstrap) move the Kong bootstrap to a Job

### DIFF
--- a/kong-control-plane-postgres.yaml
+++ b/kong-control-plane-postgres.yaml
@@ -64,15 +64,15 @@ spec:
     spec:
       serviceAccountName: kong
       initContainers:
-      - name: kong-migration
-        image: kong
+      - name: wait-for-postgres
+        image: busybox:latest
         imagePullPolicy: IfNotPresent
         env:
-          - name: KONG_PG_PASSWORD
-            value: kong
+          - name: KONG_PG_PORT
+            value: "5432"
           - name: KONG_PG_HOST
             value: postgres.kong.svc
-        command: [ "kong", "migrations", "bootstrap" ]
+        command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
       - name: kong-migration-up
         image: kong
         imagePullPolicy: IfNotPresent
@@ -81,7 +81,7 @@ spec:
             value: kong
           - name: KONG_PG_HOST
             value: postgres.kong.svc
-        command: [ "kong", "migrations", "up" ]
+        command: [ "/bin/sh", "-c", "kong migrations up && kong migrations finish" ]
       containers:
       - name: kong-control-plane
         image: kong
@@ -150,4 +150,39 @@ spec:
     - port: 8001
   selector:
     app: kong-control-plane
-
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: kong
+  name: kong-control-plane-bootstrap
+  labels:
+    app: kong-control-plane-bootstrap
+spec:
+  template:
+    metadata:
+      name: kong-control-plane-bootstrap
+      labels:
+        app: kong-control-plane
+    spec:
+      initContainers:
+      - name: wait-for-postgres
+        image: busybox:latest
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: KONG_PG_PORT
+            value: "5432"
+          - name: KONG_PG_HOST
+            value: postgres.kong.svc
+        command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
+      containers:
+      - name: kong-migration-boostrap
+        image: kong
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: KONG_PG_PASSWORD
+            value: kong
+          - name: KONG_PG_HOST
+            value: postgres.kong.svc
+        command: [ "kong", "migrations", "bootstrap" ]
+      restartPolicy: OnFailure

--- a/kong-ingress-data-plane-postgres.yaml
+++ b/kong-ingress-data-plane-postgres.yaml
@@ -21,6 +21,16 @@ spec:
       labels:
         app: kong-ingress-data-plane
     spec:
+      initContainers:
+      - name: wait-for-postgres
+        image: busybox:latest
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: KONG_PG_PORT
+            value: "5432"
+          - name: KONG_PG_HOST
+            value: postgres.kong.svc
+        command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
       containers:
       - name: kong-ingress-data-plane
         image: kong

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -55,7 +55,7 @@ while [[ "$(kubectl get pod --all-namespaces | grep -v Running | grep -v Complet
   sleep 10;
 done
 
-KONG_VERSION=$(kubectl exec -n kong -it $(kubectl get pods -n kong | grep kong | head -n 1 | awk '{print $1}') -- kong version | tr -d '[:space:]')
+KONG_VERSION=$(kubectl exec -n kong -it $(kubectl get pods -n kong | grep Running | grep kong | head -n 1 | awk '{print $1}') -- kong version | tr -d '[:space:]')
 
 kubectl port-forward -n kong deployment/kong-control-plane 8001 &
 HOST="$(kubectl get nodes --namespace kong -o jsonpath='{.items[0].status.addresses[0].address}')"


### PR DESCRIPTION
based on feedback from a previous PR the bootstrap should be ran as a batch job, `kong migrations up && kong migrations finish` should be an init job and I added a wait-for-postgres initContainer where it made sense.