### PR TITLE
chore: bump up Deployment to apps/v1

### DIFF
--- a/ee-trial/kong_trial_postgres.yaml
+++ b/ee-trial/kong_trial_postgres.yaml
@@ -91,7 +91,7 @@ spec:
     app: kong
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kong-rc

--- a/kong-control-plane-cassandra.yaml
+++ b/kong-control-plane-cassandra.yaml
@@ -37,7 +37,7 @@ subjects:
   namespace: kong
   name: kong
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: kong

--- a/kong-control-plane-postgres.yaml
+++ b/kong-control-plane-postgres.yaml
@@ -37,7 +37,7 @@ subjects:
   namespace: kong
   name: kong
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: kong

--- a/kong-dbless.yaml
+++ b/kong-dbless.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: kong

--- a/kong-ingress-data-plane-cassandra.yaml
+++ b/kong-ingress-data-plane-cassandra.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: kong

--- a/kong-ingress-data-plane-postgres.yaml
+++ b/kong-ingress-data-plane-postgres.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: kong


### PR DESCRIPTION
Deployment is available under apps/v1 apiVersion since Kubernetes 1.9
(almost 2 years ago).

Deployments under extensions/v1beta1 apiVersion are no longer served by
default from kubernetes 1.16 onwards.