### PR TITLE
chore(dependencies) update the k8s versions we test against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,21 +5,23 @@ language: generic
 
 env:
   matrix:
-    - K8S_VERSION=v1.15.0 KONG_TEST_DATABASE=postgres
-    - K8S_VERSION=v1.15.0 KONG_TEST_DATABASE=cassandra
-    - K8S_VERSION=v1.14.3 KONG_TEST_DATABASE=postgres
-    - K8S_VERSION=v1.13.7 KONG_TEST_DATABASE=postgres
+    - K8S_VERSION=v1.16.2 KONG_TEST_DATABASE=postgres
+    - K8S_VERSION=v1.16.2 KONG_TEST_DATABASE=cassandra
+    - K8S_VERSION=v1.15.3 KONG_TEST_DATABASE=postgres
+    - K8S_VERSION=v1.15.3 KONG_TEST_DATABASE=cassandra
+    - K8S_VERSION=v1.14.6 KONG_TEST_DATABASE=postgres
+    - K8S_VERSION=v1.13.10 KONG_TEST_DATABASE=postgres
     - K8S_VERSION=v1.12.9 KONG_TEST_DATABASE=postgres
     - K8S_VERSION=v1.11.10 KONG_TEST_DATABASE=postgres
 matrix:
   allow_failures:
-    - env: K8S_VERSION=v1.15.0 KONG_TEST_DATABASE=cassandra
-    - env: K8S_VERSION=v1.11.10 KONG_TEST_DATABASE=postgres
+    - env: K8S_VERSION=v1.15.3 KONG_TEST_DATABASE=cassandra
+    - env: K8S_VERSION=v1.16.2 KONG_TEST_DATABASE=cassandra
 
 
 install:
   - make setup-kong-build-tools
-  - pushd kong-build-tools && make setup-ci && popd
+  - pushd kong-build-tools && make setup-ci && make setup-tests && popd
 
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KONG_BUILD_TOOLS?=2.0.3
+KONG_BUILD_TOOLS?=2.0.6
 KONG_TEST_DATABASE?=postgres
 
 setup-kong-build-tools:


### PR DESCRIPTION
includes a kong-build-tools bump that fixes how we pin helm